### PR TITLE
deletion-ignore-not-found-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore `Not Found` errors during deletion to avoid panic.
+
 ## [0.2.3] - 2022-08-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2022-08-09
+
 ### Fixed
 
 - Fix fetching `AWSClusterRoleIdentity`.
@@ -33,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2021-10-14
 
 
-[Unreleased]: https://github.com/giantswarm/dns-operator-aws/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/giantswarm/dns-operator-aws/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/giantswarm/dns-operator-aws/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/giantswarm/dns-operator-aws/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/giantswarm/dns-operator-aws/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/giantswarm/dns-operator-aws/compare/v0.1.1...v0.2.0

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -210,12 +210,15 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope
 	controllerutil.RemoveFinalizer(awsCluster, key.DNSFinalizerName)
 	// Finally remove the finalizer
 	if err := r.Update(ctx, awsCluster); err != nil {
-		return reconcile.Result{}, err
+		clusterScope.Info("failed to remove finalizer", "reason", err.Error())
+		return reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: time.Minute,
+		}, nil
 	}
-	clusterScope.Info("removed finalizer")
+	clusterScope.Info("removed finalizer, removing from queue")
 
 	return ctrl.Result{
-		Requeue:      true,
-		RequeueAfter: time.Minute * 5,
+		Requeue: false,
 	}, nil
 }

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -203,6 +203,7 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope
 		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
+
 		return reconcile.Result{}, err
 	}
 	// AWSCluster is deleted so remove the finalizer.

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -194,7 +194,14 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope
 		return reconcile.Result{}, err
 	}
 
-	awsCluster := clusterScope.AWSCluster
+	awsCluster := &capa.AWSCluster{}
+	err := r.Get(ctx, client.ObjectKey{Name: clusterScope.AWSCluster.Name, Namespace: clusterScope.AWSCluster.Namespace}, awsCluster)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
 	// AWSCluster is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(awsCluster, key.DNSFinalizerName)
 	// Finally remove the finalizer

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -112,7 +112,6 @@ func (r *AWSClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 			for _, addr := range bastionMachineList.Items[0].Status.Addresses {
 				if addr.Type == "ExternalIP" {
 					bastionIP = addr.Address
-					log.Info("Found bastion", "externalIP", bastionIP)
 					break
 				}
 			}
@@ -197,6 +196,7 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope
 		return reconcile.Result{}, err
 	}
 
+	clusterScope.Info("removing finalizer")
 	awsCluster := &capa.AWSCluster{}
 	err := r.Get(ctx, client.ObjectKey{Name: clusterScope.AWSCluster.Name, Namespace: clusterScope.AWSCluster.Namespace}, awsCluster)
 	if err != nil {
@@ -212,6 +212,7 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope
 	if err := r.Update(ctx, awsCluster); err != nil {
 		return reconcile.Result{}, err
 	}
+	clusterScope.Info("removed finalizer")
 
 	return ctrl.Result{
 		Requeue:      true,

--- a/pkg/cloud/services/route53/errors.go
+++ b/pkg/cloud/services/route53/errors.go
@@ -2,6 +2,7 @@ package route53
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -55,6 +56,10 @@ func IsNotFound(err error) bool {
 		}
 	}
 	return false
+}
+
+func IsAlreadyExists(err error) bool {
+	return strings.Contains(err.Error(), "it already exists")
 }
 
 // IsAccessDenied returns true if the error is AccessDenied.

--- a/pkg/cloud/services/route53/errors.go
+++ b/pkg/cloud/services/route53/errors.go
@@ -59,7 +59,7 @@ func IsNotFound(err error) bool {
 }
 
 func IsAlreadyExists(err error) bool {
-	return strings.Contains(err.Error(), "it already exists")
+	return err != nil && strings.Contains(err.Error(), "it already exists")
 }
 
 // IsAccessDenied returns true if the error is AccessDenied.

--- a/pkg/cloud/services/route53/route53.go
+++ b/pkg/cloud/services/route53/route53.go
@@ -162,8 +162,9 @@ func (s *Service) changeWorkloadClusterRecords(action string) error {
 		ChangeBatch:  &route53.ChangeBatch{Changes: changes},
 	}
 
-	_, err = s.Route53Client.ChangeResourceRecordSets(input)
+	result, err := s.Route53Client.ChangeResourceRecordSets(input)
 	if err != nil {
+		s.scope.Error(err, "failed to change records", "reason", result.ChangeInfo.String())
 		return err
 	}
 

--- a/pkg/cloud/services/route53/route53.go
+++ b/pkg/cloud/services/route53/route53.go
@@ -167,7 +167,7 @@ func (s *Service) changeWorkloadClusterRecords(action string) error {
 		return err
 	}
 
-	// bastion is optional and the operation is trasactions so all must succeed
+	// bastion is optional and the operation is transactions so all must succeed
 	if s.scope.BastionIP() != "" {
 		changes := append(changes, &route53.Change{
 			Action: aws.String(action),
@@ -187,11 +187,13 @@ func (s *Service) changeWorkloadClusterRecords(action string) error {
 			HostedZoneId: aws.String(hostZoneID),
 			ChangeBatch:  &route53.ChangeBatch{Changes: changes},
 		}
+		s.scope.Info("creating bastion record")
 
-		_, err = s.Route53Client.ChangeResourceRecordSets(input)
+		r, err := s.Route53Client.ChangeResourceRecordSets(input)
 		if err != nil {
 			return err
 		}
+		s.scope.Info("resul creating bastion record", "result", r.ChangeInfo.String())
 	}
 
 	return nil

--- a/pkg/cloud/services/route53/route53.go
+++ b/pkg/cloud/services/route53/route53.go
@@ -166,13 +166,12 @@ func (s *Service) changeWorkloadClusterRecords(action string) error {
 	if IsAlreadyExists(err) {
 		// if record already exists, continue with bastion
 	} else if err != nil {
-		s.scope.Info("failed to create base DNS records", "error", err.Error())
+		s.scope.Info("failed to change base DNS records", "error", err.Error())
 		return err
 	}
 
 	// bastion is optional and the operation is transactions so all must succeed
 	if s.scope.BastionIP() != "" {
-		s.scope.Info("trying to add adding bastion record")
 		changes := []*route53.Change{
 			{
 				Action: aws.String(action),
@@ -197,11 +196,10 @@ func (s *Service) changeWorkloadClusterRecords(action string) error {
 		_, err := s.Route53Client.ChangeResourceRecordSets(input)
 		if IsAlreadyExists(err) {
 			// update record
-
 			input.ChangeBatch.Changes[0].Action = aws.String("UPSERT")
 			_, err := s.Route53Client.ChangeResourceRecordSets(input)
 			if err != nil {
-				s.scope.Info("failed to create bastion DNS records", "error", err.Error())
+				s.scope.Info("failed to update bastion DNS records", "error", err.Error())
 				return err
 			}
 
@@ -210,6 +208,7 @@ func (s *Service) changeWorkloadClusterRecords(action string) error {
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/cloud/services/route53/route53.go
+++ b/pkg/cloud/services/route53/route53.go
@@ -162,9 +162,9 @@ func (s *Service) changeWorkloadClusterRecords(action string) error {
 		ChangeBatch:  &route53.ChangeBatch{Changes: changes},
 	}
 
-	result, err := s.Route53Client.ChangeResourceRecordSets(input)
+	_, err = s.Route53Client.ChangeResourceRecordSets(input)
 	if err != nil {
-		s.scope.Error(err, "failed to change records", "reason", result.ChangeInfo.String())
+		s.scope.Error(err, "failed to change records")
 		return err
 	}
 


### PR DESCRIPTION
fix
```
2022-08-19T06:53:53.128Z	ERROR	controller-runtime.controller	Reconciler error	{"controller": "awscluster", "name": "vac07", "namespace": "org-giantswarm", "error": "InvalidChangeBatch: [Tried to delete resource record set [name='vac07.gaws.gigantic.io.', type='NS'] but it was not found]\n\tstatus code: 400, request id: 137e69ff-6c41-4f65-99af-5da7a701fb8a"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.14/pkg/internal/controller/controller.go:257
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.14/pkg/internal/controller/controller.go:231
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.14/pkg/internal/controller/controller.go:210
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.17.17/pkg/util/wait/wait.go:152
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/go/pkg/mod/k8s.io/apimachinery@v0.17.17/pkg/util/wait/wait.go:153
k8s.io/apimachinery/pkg/util/wait.Until
	/go/pkg/mod/k8s.io/apimachinery@v0.17.17/pkg/util/wait/wait.go:88
```
also had to rework the bastion  changes due the operation being transactional and the bastion is optional so it's not always there


TOWARDS https://github.com/giantswarm/roadmap/issues/1329