### PR TITLE
Add parameter to filter out which resolver rules to associate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wire parameter that allows to filter which resolver rules to associate.
+
 ## [0.5.3] - 2023-01-25
 
 ### Fixed
 
-- Skip resolver rule assocation to the VPC if one of target IPs belong to the respective VPC.
+- Skip resolver rule association to the VPC if one of target IPs belong to the respective VPC.
 
 ### Added
 

--- a/helm/dns-operator-aws/templates/deployment.yaml
+++ b/helm/dns-operator-aws/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
         - --management-cluster-name={{ .Values.managementClusterName  }}
         - --workload-cluster-basedomain={{ .Values.workloadClusterBaseDomain }}
         - --associate-resolver-rules={{ .Values.associateResolverRules }}
+        - --account-id={{ .Values.resolverRulesOwnerAccount }}
         resources:
           requests:
             cpu: 100m

--- a/helm/dns-operator-aws/values.schema.json
+++ b/helm/dns-operator-aws/values.schema.json
@@ -76,6 +76,9 @@
                 }
             }
         },
+        "resolverRulesOwnerAccount": {
+            "type": "string"
+        },
         "verticalPodAutoscaler": {
             "type": "object",
             "properties": {

--- a/helm/dns-operator-aws/values.yaml
+++ b/helm/dns-operator-aws/values.yaml
@@ -18,6 +18,9 @@ managementClusterNamespace: ""
 
 associateResolverRules: false
 
+# Associate only resolver rules owned by this AWS Account
+resolverRulesOwnerAccount: ""
+
 pod:
   user:
     id: 1000


### PR DESCRIPTION
Towards https://github.com/giantswarm/talanx/issues/92

[We added the feature to filter out which resolver rules to associate](https://github.com/giantswarm/dns-operator-aws/pull/160) but we didn't expose a parameter to pass that configuration.